### PR TITLE
Fix wormhole opening events and mission

### DIFF
--- a/data/adamas events.txt
+++ b/data/adamas events.txt
@@ -21,17 +21,17 @@ event "war against adamas"
 			
 event "andol wormhole opens"	
 	system "At Andol"
-		object "Remembrance Vortex"
+		add object "Remembrance Vortex"
 			sprite planet/wormhole
 			distance 2006.71
 			period 868.27
 			offset 191.403
 	system "Ed Andol"
-		object "Reminder Vortex"
+		add object "Reminder Vortex"
 			sprite planet/wormhole
 			distance 1838.67
 			period 1762.95
-		object "Remembrance Vortex"
+		add object "Remembrance Vortex"
 			sprite planet/wormhole
 			distance 2006.71
 			period 868.27
@@ -41,7 +41,7 @@ event "andol wormhole opens"
 			
 event "dust wormhole opens"
 	system "Ed Andol"
-		object "Reminder Vortex"
+		add object "Reminder Vortex"
 			sprite planet/wormhole
 			distance 1838.67
 			period 1762.95

--- a/data/adamas missions.txt
+++ b/data/adamas missions.txt
@@ -11,6 +11,7 @@
 mission "Adamas Wormhole Opens"
 	name "Investigate wormhole"
 	invisible
+	landing
 	description "Opens the Adamas wormhole - you shouldn't be seeing this."
 	waypoint "At Andol"
 	destination "Maker"


### PR DESCRIPTION
*  Fix wormhole opening event overriding entire system (which it probably shouldn't)
* Also fix broken wormhole because destination wormhole got overridden. (Might be intentional? If so it's a poor design.)
* Made wormhole opening mission offer on landing instead of spaceport.